### PR TITLE
Fix Dbus processes memory leak 

### DIFF
--- a/omxplayer/bus_finder.py
+++ b/omxplayer/bus_finder.py
@@ -7,8 +7,9 @@ logger = getLogger(__name__)
 
 
 class BusFinder(object):
-    def __init__(self, path=None):
+    def __init__(self, path=None, pidpath=None):
         self.path = path
+        self.pidpath = pidpath
         logger.debug('BusFinder initialised with path: %s' % path)
 
     def get_address(self):
@@ -19,6 +20,15 @@ class BusFinder(object):
             self.address = f.read().strip()
             logger.debug('Address \'%s\' parsed from file' % self.address)
         return self.address
+
+    def get_process(self):
+        self.wait_for_process_file()
+        logger.debug('Opening file at %s' % self.pidpath)
+        with open(self.pidpath, 'r') as f:
+            logger.debug('Opened file at %s' % self.pidpath)
+            self.pid = int(f.read().strip())
+            logger.debug('Process ID \'%s\' parsed from file' % self.pid)
+        return self.pid
 
     def find_address_file(self):
         """
@@ -37,6 +47,23 @@ class BusFinder(object):
 
         self.path = possible_address_files[-1]
 
+    def find_process_file(self):
+        """
+        Finds the OMXPlayer DBus Process
+        Assumes there is an alive OMXPlayer process.
+        :return:
+        """
+        possible_pid_files = []
+        while not possible_pid_files:
+            # filter is used here as glob doesn't support regexp :(
+            is_pid_file = lambda path: path.endswith('.pid')
+            possible_pid_files = filter(is_pid_file,
+                                            glob('/tmp/omxplayerdbus.*'))
+            possible_pid_files.sort(key=lambda path: os.path.getmtime(path))
+            time.sleep(0.05)
+
+        self.pidpath = possible_pid_files[-1]
+
     def wait_for_path_to_exist(self):
         while not os.path.isfile(self.path):
             time.sleep(0.05)
@@ -51,3 +78,18 @@ class BusFinder(object):
         else:
             self.find_address_file()
         self.wait_for_dbus_address_to_be_written_to_file()
+
+    def wait_for_process_file_to_exist(self):
+        while not os.path.isfile(self.pidpath):
+            time.sleep(0.05)
+
+    def wait_for_process_to_be_written_to_file(self):
+        while not os.path.getsize(self.pidpath):
+            time.sleep(0.05)
+
+    def wait_for_process_file(self):
+        if self.pidpath:
+            self.wait_for_process_file_to_exist()
+        else:
+            self.find_process_file()
+        self.wait_for_process_to_be_written_to_file()

--- a/omxplayer/player.py
+++ b/omxplayer/player.py
@@ -438,6 +438,8 @@ class OMXPlayer(object):
             os.kill(int(self.dbus_pid), signal.SIGTERM)
         except OSError:
             logger.error('Could not find the Dbus process to kill')
+        except:
+            pass
 
     @_check_player_is_active
     def get_filename(self):

--- a/omxplayer/player.py
+++ b/omxplayer/player.py
@@ -435,7 +435,7 @@ class OMXPlayer(object):
         except OSError:
             logger.error('Could not find the process to kill')
         try:
-            os.kill(self.dbus_pid, signal.SIGTERM)
+            os.kill(int(self.dbus_pid), signal.SIGTERM)
         except OSError:
             logger.error('Could not find the Dbus process to kill')
 

--- a/omxplayer/player.py
+++ b/omxplayer/player.py
@@ -110,6 +110,7 @@ class OMXPlayer(object):
             logger.debug('DBus connect attempt: {}'.format(self.tries))
             try:
                 connection = Connection(bus_address_finder.get_address())
+                self.dbus_pid = bus_address_finder.get_process()
                 logger.debug(
                     'Connected to OMXPlayer at DBus address: %s' % connection)
                 return connection
@@ -433,6 +434,10 @@ class OMXPlayer(object):
             logger.debug('SIGTERM Sent to pid: %s' % self._process.pid)
         except OSError:
             logger.error('Could not find the process to kill')
+        try:
+            os.kill(self.dbus_pid, signal.SIGTERM)
+        except OSError:
+            logger.error('Could not find the Dbus process to kill')
 
     @_check_player_is_active
     def get_filename(self):
@@ -441,6 +446,9 @@ class OMXPlayer(object):
             str: filename currently playing
         """
         return self._filename
+
+    def __del__(self):
+        self.quit()
 
 
 #  MediaPlayer2.Player types:


### PR DESCRIPTION
My fix to #32 -> Grab the Dbus process ID as well, so that it can be killed when calling
quit() on the player.