### PR TITLE
Convert iterator to list.

### DIFF
--- a/omxplayer/bus_finder.py
+++ b/omxplayer/bus_finder.py
@@ -30,8 +30,8 @@ class BusFinder(object):
         while not possible_address_files:
             # filter is used here as glob doesn't support regexp :(
             isnt_pid_file = lambda path: not path.endswith('.pid')
-            possible_address_files = filter(isnt_pid_file,
-                                            glob('/tmp/omxplayerdbus.*'))
+            possible_address_files = list(filter(isnt_pid_file,
+                                            glob('/tmp/omxplayerdbus.*')))
             possible_address_files.sort(key=lambda path: os.path.getmtime(path))
             time.sleep(0.05)
 


### PR DESCRIPTION
filter() returns an iterator, not a list, and we can't use sort() on iterators.