### PR TITLE
Updating per pull request #40

### DIFF
--- a/tests/test_omxplayer.py
+++ b/tests/test_omxplayer.py
@@ -89,7 +89,7 @@ class OMXPlayerTests(unittest.TestCase):
         popen.return_value = omxplayer_process
         self.patch_and_run_omxplayer()
         self.player.quit()
-        killpg.assert_called_once_with(omxplayer_process.pid, signal.SIGTERM)
+        killpg.assert_called_once_with(omxplayer_process.pid, signal.SIGINT)
 
     def test_quitting_waits_for_omxplayer_to_die(self, popen, sleep, isfile, killpg, *args):
         omxplayer_process = Mock()


### PR DESCRIPTION
Change SIGTERM to SIGINT to make sure echo is on after exiting Omxplayer to avoid no input on console or freezing console.

Per pull request #40 and issue #37 