### PR TITLE
Add apt-get install python-dbus instruction to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Status](https://travis-ci.org/willprice/python-omxplayer-wrapper.svg)](https://t
 > Control OMXPlayer from Python on the Raspberry Pi.
 
 ## Install
+Make sure dbus is installed:
+```shell
+$ sudo apt-get install python-dbus
+```
+
 For someone who just wants to use the package:
 ```shell
 $ python setup.py install


### PR DESCRIPTION
A simple instruction on the dbus dependency, could have saved me a couple of minutes. (I'm running raspbian jessie _lite_, this might not be necessary for vanilla raspbian systems?)