### PR TITLE
Check if filename is a URL before checking if file exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,12 @@ but import it from other python packages
 from omxplayer import OMXPlayer
 from time import sleep
 
-# This will start an `omxplayer` process, this might 
-# fail the first time you run it, currently in the 
+file_path_or_url = 'path/to/file.mp4'
+
+# This will start an `omxplayer` process, this might
+# fail the first time you run it, currently in the
 # process of fixing this though.
-player = OMXPlayer('path/to/file.mp4')
+player = OMXPlayer(file_path_or_url)
 
 # The player will initially be paused
 
@@ -53,7 +55,26 @@ player.pause()
 player.quit()
 ```
 
-Playing a file from a URL (courtesy of @jappe999)
+Playing a stream from a URL (e.g. a live RTMP or RTSP stream) works the same as with a file path, just change the "source" string parameter given to `OMXPlayer` to a URL instead of a file path.
+```python
+from omxplayer import OMXPlayer
+from time import sleep
+
+file_path_or_url = 'rtmp://192.168.0.1/live/test'
+
+player = OMXPlayer(file_path_or_url)
+
+# The player will initially be paused
+
+player.play()
+sleep(5)
+player.pause()
+
+# Kill the `omxplayer` process gracefully.
+player.quit()
+```
+
+Playing a file from a URL by downloading the network file (courtesy of @jappe999)
 ```python
 import urllib
 from omxplayer import OMXPlayer

--- a/README.md
+++ b/README.md
@@ -74,22 +74,6 @@ player.pause()
 player.quit()
 ```
 
-Playing a file from a URL by downloading the network file (courtesy of @jappe999)
-```python
-import urllib
-from omxplayer import OMXPlayer
-
-file_name = YOUR_FILE_URL
-
-try:
-        urllib.urlretrieve(file_name, 'file.mp3')
-        player = OMXPlayer('file.mp3', ['-o', 'local'])
-        player.play()
-except Exception as e:
-        print e
-
-```
-
 ## Docs
 You can read the docs here:
 [python-omxplayer-wrapper.rtfd.org](http://python-omxplayer-wrapper.rtfd.org)

--- a/omxplayer/player.py
+++ b/omxplayer/player.py
@@ -81,7 +81,7 @@ class OMXPlayer(object):
         self._process = self._setup_omxplayer_process(source)
         self._connection = self._setup_dbus_connection(self._Connection, self._bus_address_finder)
 
-    # For backwards compatibility
+    # For backward compatibility
     def _load_file(self, source):
         self._load_source(source)
 
@@ -516,12 +516,12 @@ class OMXPlayer(object):
         """
         return self._source
 
-    # For backwards compatibility
+    # For backward compatibility
     @_check_player_is_active
     def get_filename(self):
         """
         Returns:
-            str: source currently playing, for backwards compatibility
+            str: source currently playing, for backward compatibility
         """
         return self.get_source()
 

--- a/omxplayer/player.py
+++ b/omxplayer/player.py
@@ -5,6 +5,7 @@ import signal
 import logging
 import threading
 import math
+import urlparse
 
 from decorator import decorator
 from glob import glob
@@ -35,7 +36,7 @@ class OMXPlayer(object):
     This works by speaking to OMXPlayer over DBus sending messages.
 
     Args:
-        filename (str): Path to the file you wish to play
+        filename (str): Path to the file or URL you wish to play
         args (list): used to pass option parameters to omxplayer.  see: https://github.com/popcornmix/omxplayer#synopsis
 
 
@@ -102,7 +103,8 @@ class OMXPlayer(object):
 
     def _setup_omxplayer_process(self, filename):
             logger.debug('Setting up OMXPlayer process')
-            if not os.path.isfile(filename):
+            filename_url = urlparse.urlsplit(filename)
+            if not filename_url.scheme and not os.path.isfile(filename):
                 raise FileNotFoundError("Could not find: {}".format(filename))
             with open(os.devnull, 'w') as devnull:
                 process = self._run_omxplayer(filename, devnull)

--- a/omxplayer/player.py
+++ b/omxplayer/player.py
@@ -81,10 +81,6 @@ class OMXPlayer(object):
         self._process = self._setup_omxplayer_process(source)
         self._connection = self._setup_dbus_connection(self._Connection, self._bus_address_finder)
 
-    # For backward compatibility
-    def _load_file(self, source):
-        self._load_source(source)
-
     def _run_omxplayer(self, source, devnull):
         def on_exit():
             logger.info("OMXPlayer process is dead, all DBus calls from here "
@@ -521,7 +517,10 @@ class OMXPlayer(object):
     def get_filename(self):
         """
         Returns:
-            str: source currently playing, for backward compatibility
+            str: source currently playing
+
+        .. deprecated:: 0.2.0
+           Use: :func:`get_source` instead.
         """
         return self.get_source()
 

--- a/tests/test_omxplayer.py
+++ b/tests/test_omxplayer.py
@@ -117,7 +117,7 @@ class OMXPlayerTests(unittest.TestCase):
             self.patch_and_run_omxplayer()
             ospath.isfile.assert_called_once_with(self.TEST_FILE_NAME)
 
-    def test_not_checks_url_before_launching_player(self, *args):
+    def test_player_doesnt_check_source_path_exists_for_a_url(self, *args):
         with patch('os.path') as ospath:
             self.patch_and_run_omxplayer_url()
             ospath.isfile.assert_not_called()


### PR DESCRIPTION
Check if filename is a URL before checking if file exists.

It does so by parsing the `filename` and checking if it's a URL with a scheme (the "http" or "rstp" in "http://youtube.com/..." or in "rstp://192.168.1.15:5544/") before parsing if a file exists. So, if the path is a file, it will still do the check.

This should solve #35.

I needed it so I added it (and I tested it, I'm already using this fix).