### PR TITLE
Add events to player methods

### DIFF
--- a/omxplayer/player.py
+++ b/omxplayer/player.py
@@ -36,10 +36,13 @@ class OMXPlayer(object):
 
     Args:
         filename (str): Path to the file you wish to play
-        args (list): used to pass option parameters to omxplayer.
-        multiple argument example:
-        # OMXPlayer('path.mp4', args=['--no-osd', '--no-keys', '-b'])
-        info: https://github.com/popcornmix/omxplayer#synopsis
+        args (list): used to pass option parameters to omxplayer.  see: https://github.com/popcornmix/omxplayer#synopsis
+
+
+    Multiple argument example:
+
+    >>> OMXPlayer('path.mp4', args=['--no-osd', '--no-keys', '-b'])
+
     """
     def __init__(self, filename,
                  args=[],
@@ -63,11 +66,15 @@ class OMXPlayer(object):
         time.sleep(0.5)  # Wait for the DBus interface to be initialised
         self.pause()
 
-        # events
+        #: Event called on pause ``callback(player)``
         self.pauseEvent = Event()
+        #: Event called on play ``callback(player)``
         self.playEvent = Event()
+        #: Event called on stop ``callback(player)``
         self.stopEvent = Event()
+        #: Event called on seek ``callback(player, relative_position)``
         self.seekEvent = Event()
+        #: Event called on setting position ``callback(player, absolute_position)``
         self.positionEvent = Event()
 
     def _run_omxplayer(self, filename, devnull):

--- a/omxplayer/player.py
+++ b/omxplayer/player.py
@@ -14,6 +14,8 @@ import omxplayer.bus_finder
 from omxplayer.dbus_connection import DBusConnection, \
                                       DBusConnectionError
 
+from evento import Event
+
 #### CONSTANTS ####
 RETRY_DELAY = 0.05
 
@@ -60,6 +62,13 @@ class OMXPlayer(object):
                                                      bus_address_finder)
         time.sleep(0.5)  # Wait for the DBus interface to be initialised
         self.pause()
+
+        # events
+        self.pauseEvent = Event()
+        self.playEvent = Event()
+        self.stopEvent = Event()
+        self.seekEvent = Event()
+        self.positionEvent = Event()
 
     def _run_omxplayer(self, filename, devnull):
         def on_exit():
@@ -293,6 +302,8 @@ class OMXPlayer(object):
             None:
         """
         self._get_player_interface().Pause()
+        self._is_playing = False
+        self.pauseEvent(self)
 
     @_check_player_is_active
     def play_pause(self):
@@ -302,10 +313,15 @@ class OMXPlayer(object):
         """
         self._get_player_interface().PlayPause()
         self._is_playing = not self._is_playing
+        if self._is_playing:
+            self.playEvent(self)
+        else:
+            self.pauseEvent(self)
 
     @_check_player_is_active
     def stop(self):
         self._get_player_interface().Stop()
+        self.stopEvent(self)
 
     @_check_player_is_active
     def seek(self, relative_position):
@@ -314,6 +330,7 @@ class OMXPlayer(object):
             relative_position (float): The position in seconds to seek to.
         """
         self._get_player_interface().Seek(Int64(relative_position))
+        self.seekEvent(self, relative_position)
 
     @_check_player_is_active
     def set_position(self, position):
@@ -322,6 +339,7 @@ class OMXPlayer(object):
             position (float): The position in seconds.
         """
         self._get_player_interface().SetPosition(ObjectPath("/not/used"), Int64(position*1000*1000))
+        self.positionEvent(self, position)
 
     @_check_player_is_active
     def list_video(self):
@@ -400,6 +418,8 @@ class OMXPlayer(object):
         """
         if not self.is_playing():
             self.play_pause()
+            self._is_playing = True
+            self.playEvent(self)
 
     def _get_root_interface(self):
         return self.connection.root_interface

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ snowballstemmer==1.2.0
 Sphinx==1.2.3
 sphinx-rtd-theme==0.1.7
 sphinxcontrib-napoleon==0.3.3
+evento==1.0.0


### PR DESCRIPTION
## Description
Adds events (contributed by @markkorput)

I've taken @markkorput branch and refactored the tests to use mocks, which makes them a bit more robust as we assert how many times the events are called rather than just checking they are called.

There's no docs on this functionality so this needs to be addressed before merging in.

* **Status**: *READY*

## Related PRs
Branch              | PR
--------------------|-------
feature-callbacks | https://github.com/willprice/python-omxplayer-wrapper/pull/53


## Todos
- [x] Documentation