### PR TITLE
Pausing at initialisation optional 

### DIFF
--- a/omxplayer/player.py
+++ b/omxplayer/player.py
@@ -47,7 +47,8 @@ class OMXPlayer(object):
     def __init__(self, filename,
                  args=[],
                  bus_address_finder=None,
-                 Connection=None):
+                 Connection=None,
+                 pause=True):
         logger.debug('Instantiating OMXPlayer')
 
         self.args = args
@@ -70,7 +71,7 @@ class OMXPlayer(object):
 
         self._process = None
         self._connection = None
-        self.load(filename)
+        self.load(filename, pause=pause)
 
     def _load_file(self, filename):
         if self._process:
@@ -141,7 +142,7 @@ class OMXPlayer(object):
 
         return decorator(wrapped, fn)
 
-    def load(self, file_path):
+    def load(self, file_path, pause=True):
         """
         Loads a new file from ``file_path`` by killing the current
         ``omxplayer`` process and forking a new one.
@@ -151,8 +152,9 @@ class OMXPlayer(object):
         """
         self._filename = file_path
         self._load_file(file_path)
-        time.sleep(0.5)  # Wait for the DBus interface to be initialised
-        self.pause()
+        if pause:
+            time.sleep(0.5)  # Wait for the DBus interface to be initialised
+            self.pause()
 
     """ ROOT INTERFACE METHODS """
 

--- a/tests/test_omxplayer.py
+++ b/tests/test_omxplayer.py
@@ -252,3 +252,19 @@ class OMXPlayerTests(unittest.TestCase):
                                 pause=False)
         
             self.assertEqual(mock_method.call_count, 0)
+
+    def test_load_pauses_by_default(self, popen, sleep, isfile, killpg, *args):
+        with patch.object(OMXPlayer, 'pause', return_value=None) as mock_method:
+            self.patch_and_run_omxplayer()
+            self.assertEqual(mock_method.call_count, 1)
+            self.player.load('./test2.mp4')
+            self.assertEqual(mock_method.call_count, 2)
+
+    def test_load_without_pause(self, popen, sleep, isfile, killpg, *args):
+        with patch.object(OMXPlayer, 'pause', return_value=None) as mock_method:
+            self.patch_and_run_omxplayer()
+            # the constructor calls load which pauses by default
+            self.assertEqual(mock_method.call_count, 1)
+            self.player.load('./test2.mp4', pause=False)
+            # verify pause hasn't been called again
+            self.assertEqual(mock_method.call_count, 1)

--- a/tests/test_omxplayer.py
+++ b/tests/test_omxplayer.py
@@ -234,3 +234,21 @@ class OMXPlayerTests(unittest.TestCase):
             killpg.assert_called_once_with(omxplayer_process.pid, signal.SIGTERM)
             # verify a new process was started for the second time
             self.assertEqual(popen.call_count, 2)
+
+    
+    def test_init_pauses_by_default(self, popen, sleep, isfile, killpg, *args):
+        with patch.object(OMXPlayer, 'pause', return_value=None) as mock_method:
+            self.patch_and_run_omxplayer()
+            self.assertEqual(mock_method.call_count, 1)
+
+    def test_init_without_pause(self, popen, sleep, isfile, killpg, *args):
+        with patch.object(OMXPlayer, 'pause', return_value=None) as mock_method:
+            # self.patch_and_run_omxplayer(pause=False)
+            bus_address_finder = Mock()
+            bus_address_finder.get_address.return_val = "example_bus_address"
+            self.player = OMXPlayer(self.TEST_FILE_NAME,
+                                bus_address_finder=bus_address_finder,
+                                Connection=Mock(),
+                                pause=False)
+        
+            self.assertEqual(mock_method.call_count, 0)


### PR DESCRIPTION
## Description
Implements feature request #51: adds additional _pause_ argument to the OMXPlayer \__init__ and load methods to disable the automatic pausing of the new omxplayer process.

* **Status**: *READY*

## Todos
- [x] Tests
- [ ] Documentation
