### PR TITLE
Allow control of multiple instances via dbus

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,9 @@ file_path_or_url = 'path/to/file.mp4'
 # process of fixing this though.
 player = OMXPlayer(file_path_or_url)
 
-# The player will initially be paused
-
-player.play()
-sleep(5)
 player.pause()
+sleep(5)
+player.play()
 
 # Kill the `omxplayer` process gracefully.
 player.quit()
@@ -64,14 +62,31 @@ file_path_or_url = 'rtmp://192.168.0.1/live/test'
 
 player = OMXPlayer(file_path_or_url)
 
-# The player will initially be paused
-
-player.play()
-sleep(5)
 player.pause()
+sleep(5)
+player.play()
 
 # Kill the `omxplayer` process gracefully.
 player.quit()
+```
+
+Playing several instances of omxplayer simultaneously
+```python
+from omxplayer import OMXPlayer
+
+# Use default dbus name for first instance
+player1 = OMXPlayer(file_path_or_url1, pause=True)
+# Name of dbus for second instance is just an example
+player2 = OMXPlayer(file_path_or_url2, dbus_name='org.mpris.MediaPlayer2.omxplayer1', pause=True)
+
+# Players are initially paused due to the 'pause' argument, but this is not necessary
+# That way we can start them synchronously
+player1.play()
+player2.play()
+
+# Kill the `omxplayer` processes gracefully.
+player1.quit()
+player2.quit()
 ```
 
 ## Usage patterns

--- a/omxplayer/dbus_connection.py
+++ b/omxplayer/dbus_connection.py
@@ -16,10 +16,11 @@ class DBusConnection(object):
         player_interface: org.mpris.MediaPlayer2.Player interface  proxy object
     """
 
-    def __init__(self, bus_address):
+    def __init__(self, bus_address, dbus_name=None):
         self.root_interface = None
         self.player_interface = None
         self._address = bus_address
+        self._dbus_name = dbus_name
         self._bus = self._create_connection()
         self.proxy = self._create_proxy()
 
@@ -29,7 +30,10 @@ class DBusConnection(object):
     def _create_proxy(self):
         try:
             # introspection fails so it is disabled
-            proxy = self._bus.get_object('org.mpris.MediaPlayer2.omxplayer',
+            dbus_name = 'org.mpris.MediaPlayer2.omxplayer'
+            if self._dbus_name:
+                dbus_name = self._dbus_name
+            proxy = self._bus.get_object(dbus_name,
                                          '/org/mpris/MediaPlayer2',
                                          introspect=False)
             self._create_media_interfaces_on_proxy(proxy)

--- a/omxplayer/player.py
+++ b/omxplayer/player.py
@@ -55,12 +55,14 @@ class OMXPlayer(object):
                  args=[],
                  bus_address_finder=None,
                  Connection=None,
+                 dbus_name=None,
                  pause=False):
         logger.debug('Instantiating OMXPlayer')
 
         self.args = args
         self._is_playing = True
         self._source = source
+        self._dbus_name = dbus_name
         self._Connection = Connection if Connection else DBusConnection
         self._bus_address_finder = bus_address_finder if bus_address_finder else BusFinder()
 
@@ -96,6 +98,8 @@ class OMXPlayer(object):
             on_exit()
 
         command = ['omxplayer'] + self.args + [source]
+        if self._dbus_name:
+            command += ['--dbus_name', self._dbus_name]
         logger.debug("Opening omxplayer with the command: %s" % command)
         process = subprocess.Popen(command,
                                    stdin=devnull,
@@ -122,7 +126,7 @@ class OMXPlayer(object):
         while tries < 50:
             logger.debug('DBus connect attempt: {}'.format(tries))
             try:
-                connection = Connection(bus_address_finder.get_address())
+                connection = Connection(bus_address_finder.get_address(), self._dbus_name)
                 logger.debug(
                     'Connected to OMXPlayer at DBus address: %s' % connection)
                 return connection


### PR DESCRIPTION
## Description
Added another argument to OMXPlayer constructor - dbus_name. Using this name we'll be able to communicate with multiple running instances of omxplayer