### PR TITLE
Add missing dependency libglib2.0-dev to docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,12 +5,13 @@ You'll need the following dependencies:
 
 * `libdbus-1`
 * `libdbus-1-dev`
+* `libglib2.0-dev`
 
 OS pre-requisite installation
 
 .. code-block:: bash
 
-  $ sudo apt-get update && sudo apt-get install -y libdbus-1{,-dev}
+  $ sudo apt-get update && sudo apt-get install -y libdbus-1{,-dev} libglib2.0-dev
 
 With `pipenv <http://docs.pipenv.org/en/latest/>`_
 


### PR DESCRIPTION
## Description
As mentioned in issue #198 the `libglib2.0-dev` is not pre-installed in current Raspbian versions. Had the same occur to me with a fresh Raspbian Buster on a RPi 3+ today. To reduce friction for first time users, I suggest adding it to the docs as there is no harm for users that already have it installed on their systems.

* **Status**: *READY*

## Steps to Test or Reproduce

1. Install current Raspbian default variant
2. Install old documented dependencies
3. `pip3 install omxplayer-wrapper`
4. Get an error
5. `apt install libglib2.0-dev`
6. again: `pip3 install omxplayer-wrapper`
7. Installation works
